### PR TITLE
Update website for 0.4.1 release

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -172,7 +172,7 @@ header ul li {
 .osPrimary {
     width: 50%;
     float: left;
-    padding: 3rem 3rem 4rem 3rem;
+    padding: 3rem 3rem 2rem 3rem;
     border-bottom: 1px solid rgba(0, 0, 0, 0.1);
 }
 
@@ -406,4 +406,10 @@ footer .onion img {
     .osSecondary {
         padding: 2rem;
     }
+}
+
+.cpu-arch-info {
+    padding-top: 0.5rem;
+    color: grey;
+    font-size: small;
 }

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
         <img src="assets/img/apple-logo.png" alt="Apple Logo">
         <p class="title">MacOS</p>
           <a class="button"
-              href="https://github.com/freedomofpress/dangerzone/releases/download/v0.4.1/Dangerzone-0.4.1-amd64.dmg">Intel chip</a>
+              href="https://github.com/freedomofpress/dangerzone/releases/download/v0.4.1/Dangerzone-0.4.1-i686.dmg">Intel chip</a>
           <a class="button"
           href="https://github.com/freedomofpress/dangerzone/releases/download/v0.4.1/Dangerzone-0.4.1-arm64.dmg">Apple Silicon chip</a>
           <p class="cpu-arch-info">&#8505;&#65039;

--- a/index.html
+++ b/index.html
@@ -71,21 +71,28 @@
     </div>
   </section>
   <section id="downloads" class="wrapper clearfix">
-    <h2>Download Dangerzone 0.4.0</h2>
+    <h2>Download Dangerzone 0.4.1</h2>
     <div class="clearfix">
       <div class="osPrimary">
         <img src="assets/img/apple-logo.png" alt="Apple Logo">
         <p class="title">MacOS</p>
-        <a class="button"
-          href="https://github.com/freedomofpress/dangerzone/releases/download/v0.4.0/Dangerzone-0.4.0.dmg">Download for
-          MacOS</a>
+          <a class="button"
+              href="https://github.com/freedomofpress/dangerzone/releases/download/v0.4.1/Dangerzone-0.4.1-amd64.dmg">Intel chip</a>
+          <a class="button"
+          href="https://github.com/freedomofpress/dangerzone/releases/download/v0.4.1/Dangerzone-0.4.1-arm64.dmg">Apple Silicon chip</a>
+          <p class="cpu-arch-info">&#8505;&#65039;
+            <a href="https://support.apple.com/en-us/HT211814">Which one do I have?</a>
+          </p>
       </div>
       <div class="osPrimary">
         <img src="assets/img/windows-logo.png" alt="Windows Logo">
         <p class="title">Windows</p>
         <a class="button"
-          href="https://github.com/freedomofpress/dangerzone/releases/download/v0.4.0/Dangerzone-0.4.0.msi">Download for
+          href="https://github.com/freedomofpress/dangerzone/releases/download/v0.4.1/Dangerzone-0.4.1.msi">Download for
           Windows</a>
+          <p class="cpu-arch-info">&#65039; <!-- invalid emoji to display same-height whitespace as macOS -->
+            <pre></pre>
+          </p>
       </div>
     </div>
     <div class="clearfix">

--- a/index.html
+++ b/index.html
@@ -100,13 +100,13 @@
         <img src="assets/img/ubuntu-logo.png" alt="Ubuntu Logo">
         <p class="title">Ubuntu / Debian / Linux Mint</p>
         <a class="button"
-          href="https://github.com/freedomofpress/dangerzone/blob/v0.4.0/INSTALL.md">Install</a>
+          href="https://github.com/freedomofpress/dangerzone/blob/v0.4.1/INSTALL.md">Install</a>
       </div>
       <div class="osSecondary">
         <img src="assets/img/fedora-logo.png" alt="Fedora Logo">
         <p class="title">Fedora</p>
         <a class="button"
-          href="https://github.com/freedomofpress/dangerzone/blob/v0.4.0/INSTALL.md">Install</a>
+          href="https://github.com/freedomofpress/dangerzone/blob/v0.4.1/INSTALL.md">Install</a>
       </div>
       <div class="osSecondary">
         <img src="assets/img/linux-logo.png" alt="Linux Logo">


### PR DESCRIPTION
- updates download links
- adds apple silicon download link to macOS, along with a clarification link for helping users know which one they have

![0 4 1](https://user-images.githubusercontent.com/47065258/223722766-bc1895b6-bbb5-403f-84b9-3700873721c4.png)
