### PR TITLE
Add checksums for MacOS/Windows artifacts

### DIFF
--- a/checksums.txt
+++ b/checksums.txt
@@ -1,0 +1,3 @@
+ecaa65f030cdf2ecdd422c134b4c5951249dbd85d8a7bcce33ec45838f7fff49  Dangerzone-0.4.1-arm64.dmg
+7fc652c81efd45318e6b07372c6c075c345a55730e0b8b4b30cd8ace8a5fe0a1  Dangerzone-0.4.1-i686.dmg
+9b2a1231327ae5eab7803cf3644863f5e9eefde5de71780f26782b4fde95a6a1  Dangerzone-0.4.1.msi

--- a/index.html
+++ b/index.html
@@ -72,6 +72,7 @@
   </section>
   <section id="downloads" class="wrapper clearfix">
     <h2>Download Dangerzone 0.4.1</h2>
+    <a href="checksums.txt">Checksums (SHA-256)</a>
     <div class="clearfix">
       <div class="osPrimary">
         <img src="assets/img/apple-logo.png" alt="Apple Logo">


### PR DESCRIPTION
Add a file with the checksums for the artifacts that the user can download. These checksums are computed with `sha256sum`.

Closes #13