### PR TITLE
Fix rendering of images side-by-side

### DIFF
--- a/about.html
+++ b/about.html
@@ -45,8 +45,8 @@
         <p>The truth is, as a journalist, it’s your <em>job</em> to open documents from strangers, whether you get them in an email, a Signal or WhatsApp message, or through SecureDrop. Journalists also must open and read documents downloaded from all manner of websites, from leaked or hacked email dumps, or from any number of other potentially untrustworthy sources.</p>
         <p>
           <div class="screenshots">
-            <img src="assets/img/screenshot-settings.png" alt="Dangerzone Settings">
-            <img src="assets/img/screenshot-conversions.png" alt="Dangerzone File Conversions">
+            <img class="adjacent" src="assets/img/screenshot-settings.png" alt="Dangerzone Settings">
+            <img class="adjacent" src="assets/img/screenshot-conversions.png" alt="Dangerzone File Conversions">
           </div>
         </p>
         <p>Dangerzone aims to solve this problem. You can install Dangerzone on your Mac, Windows, or Linux computer, and then use it to open a variety of types of documents: PDFs, Microsoft Office or LibreOffice documents, or images. Even if the original document is dangerous and would normally hack your computer, Dangerzone will convert it into a safe PDF that you can open and read.</p>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -218,17 +218,17 @@ header ul li {
 /*SCREENSHOTS*/
 .screenshots {
     display: flex;
+    flex-wrap: wrap;
 }
 
-.screenshots img{
-    flex: 50%;
+.screenshots .adjacent {
+    width: 50%;
     padding: 5px;
-    width: 100%;
 }
 
-@media screen and (max-width: 800px) {
-    .screenshots {
-        display: block;
+@media screen and (max-width: 960px) {
+    .screenshots .adjacent {
+        width: 100%;
     }
 }
 


### PR DESCRIPTION
Improve the CSS style for showing two screenshots side-by-side in a responsive way.

Tested on Firefox, Chrome, and Safari.

Fixes #15