### PR TITLE
Containerize for static nginx k8s deployent

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,9 @@
+# sha256 as of 2023-07-05
+FROM nginx:mainline-alpine@sha256:2d4efe74ef541248b0a70838c557de04509d1115dec6bfc21ad0d66e41574a8a
+
+COPY deploy/nginx.conf /etc/nginx
+RUN mkdir -p /opt/nginx/run /opt/nginx/webroot/assets && chown -R nginx:nginx /opt/nginx
+
+USER nginx
+COPY --chown=nginx:nginx index.html about.html checksums.txt favicon.ico /opt/nginx/webroot/
+COPY --chown=nginx:nginx assets/ /opt/nginx/webroot/assets/

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,33 @@
+pid /opt/nginx/run/nginx.pid;
+
+events {
+}
+
+http {
+    include /etc/nginx/mime.types;
+    sendfile on;
+
+    server {
+        listen 5080;
+        absolute_redirect off;
+        port_in_redirect off;
+
+        client_body_temp_path /opt/nginx/run/client_temp;
+        proxy_temp_path /opt/nginx/run/proxy_temp_path;
+        fastcgi_temp_path /opt/nginx/run/fastcgi_temp;
+        uwsgi_temp_path /opt/nginx/run/uwsgi_temp;
+        scgi_temp_path /opt/nginx/run/scgi_temp;
+
+        merge_slashes off;
+
+        location / {
+            root /opt/nginx/webroot;
+            index index.html;
+        }
+
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Referrer-Policy "same-origin" always;
+    }
+}


### PR DESCRIPTION
We'd like to deploy this site to FPF's own infrastructure, so add a small nginx container that can be used to serve the files.

In the future, merges to this repo will be picked up by the same infrastructure as other FPF web sites/static docs sites.

A followup should be made after DNS is pointed to GKE to remove the `CNAME` file for Github Pages, as it will no longer be needed.