### PR TITLE
Fix invalid link typo to Fedora install instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
         <img src="assets/img/fedora-logo.png" alt="Fedora Logo">
         <p class="title">Fedora</p>
         <a class="button"
-          href="https://githufb.com/freedomofpress/dangerzone/blob/v0.5.1/INSTALL.md">Install</a>
+          href="https://github.com/freedomofpress/dangerzone/blob/v0.5.1/INSTALL.md">Install</a>
       </div>
       <div class="osSecondary">
         <img src="assets/img/linux-logo.png" alt="Linux Logo">


### PR DESCRIPTION
Basically what the title says. Fixed a link typo.

![image](https://github.com/freedomofpress/dangerzone.rocks/assets/62346025/cfaf6fbe-62b8-4883-af25-57ee900777f8)
