### PR TITLE
Remove checksums.txt file from Dockerfile

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -5,5 +5,5 @@ COPY deploy/nginx.conf /etc/nginx
 RUN mkdir -p /opt/nginx/run /opt/nginx/webroot/assets && chown -R nginx:nginx /opt/nginx
 
 USER nginx
-COPY --chown=nginx:nginx index.html about.html checksums.txt favicon.ico /opt/nginx/webroot/
+COPY --chown=nginx:nginx index.html about.html favicon.ico /opt/nginx/webroot/
 COPY --chown=nginx:nginx assets/ /opt/nginx/webroot/assets/


### PR DESCRIPTION
The checksums.txt file was replaced by a reference to our verification instructions on commit aecfc2b158eabc32e69630969a90477b6c860d0b. Remove this file from the Dockerfile as well, so that we can build our                                                                                                                                                                                container image.  