### PR TITLE
Add a basic blog and RSS feed

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,16 +1,27 @@
+const pluginRss = require("@11ty/eleventy-plugin-rss");
+
 module.exports = function(eleventyConfig) {
-    eleventyConfig.addPassthroughCopy("src/assets")
-    eleventyConfig.addPassthroughCopy("src/favicon.ico")
+    eleventyConfig.addPassthroughCopy("src/assets");
+    eleventyConfig.addPassthroughCopy("src/favicon.ico");
+    eleventyConfig.addPlugin(pluginRss);
 
     eleventyConfig.addCollection("posts", function(collection) {
-        return collection.getFilteredByGlob("src/posts/*.md");
-    })
+        return collection.getFilteredByGlob("src/news/*.md");
+    });
+
+    eleventyConfig.addFilter("dateIso", date => {
+        return date.toISOString();
+    });
+
+    eleventyConfig.addFilter("dateReadable", date => {
+       return date.toDateString();
+    });
 
     return {
         dir: {
             input: "src",
             output: "dist",
-            includes: '_layouts',
+            includes: "_layouts"
         }
-    }
+    };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "dangerzone.rocks",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "@11ty/eleventy-plugin-rss": "^1.0.5"
+      },
       "devDependencies": {
         "@11ty/eleventy": "^2.0.1"
       }
@@ -103,10 +106,24 @@
         "url": "https://opencollective.com/11ty"
       }
     },
+    "node_modules/@11ty/eleventy-plugin-rss": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-rss/-/eleventy-plugin-rss-1.2.0.tgz",
+      "integrity": "sha512-YzFnSH/5pObcFnqZ2sAQ782WmpOZHj1+xB9ydY/0j7BZ2jUNahn53VmwCB/sBRwXA/Fbwwj90q1MLo01Ru0UaQ==",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "posthtml": "^0.16.6",
+        "posthtml-urls": "1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/11ty"
+      }
+    },
     "node_modules/@11ty/eleventy-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy-utils/-/eleventy-utils-1.0.2.tgz",
-      "integrity": "sha512-Zy2leMK1DQR6Q6ZPSagv7QpJaAz9uVbb+RmVetYFp3foMeQtOSZx7w2u5daRFmP+PeNq9vO9H4xtBToYFWZwHA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-utils/-/eleventy-utils-1.0.3.tgz",
+      "integrity": "sha512-nULO91om7vQw4Y/UBjM8i7nJ1xl+/nyK4rImZ41lFxiY2d+XUz7ChAj1CDYFjrLZeu0utAYJTZ45LlcHTkUG4g==",
       "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0"
@@ -300,8 +317,7 @@
     "node_modules/any-promise": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-0.1.0.tgz",
-      "integrity": "sha512-lqzY9o+BbeGHRCOyxQkt/Tgvz0IZhTmQiA+LxQW8wSNpcTbj8K+0cZiSEvbpNZZP9/11Gy7dnLO3GNWUXO4d1g==",
-      "dev": true
+      "integrity": "sha512-lqzY9o+BbeGHRCOyxQkt/Tgvz0IZhTmQiA+LxQW8wSNpcTbj8K+0cZiSEvbpNZZP9/11Gy7dnLO3GNWUXO4d1g=="
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -468,14 +484,19 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
-      "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "dev": true,
       "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.1",
-        "set-function-length": "^1.1.1"
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -591,10 +612,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -608,17 +628,20 @@
       }
     },
     "node_modules/define-data-property": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
-      "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.2.1",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/dependency-graph": {
@@ -652,7 +675,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
       "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-      "dev": true,
       "dependencies": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
@@ -666,7 +688,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
@@ -675,7 +696,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -687,7 +707,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
       "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "dev": true,
       "dependencies": {
         "domelementtype": "^2.2.0"
       },
@@ -702,7 +721,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
       "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "dev": true,
       "dependencies": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -746,7 +764,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
       "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -764,6 +781,27 @@
       },
       "bin": {
         "errno": "cli.js"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escape-html": {
@@ -939,15 +977,19 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
-      "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
       "dev": true,
       "dependencies": {
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
         "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1055,21 +1097,21 @@
       }
     },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
-      "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.2.2"
+        "es-define-property": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -1121,7 +1163,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
       "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
-      "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -1140,7 +1181,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/http-equiv-refresh/-/http-equiv-refresh-1.0.0.tgz",
       "integrity": "sha512-TScO04soylRN9i/QdOdgZyhydXg9z6XdaGzEyOgDKycePeDeTT4KvigjBcI+tgfTlieLWauGORMq5F1eIDa+1w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -1262,8 +1302,7 @@
     "node_modules/is-json": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-json/-/is-json-2.0.1.tgz",
-      "integrity": "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==",
-      "dev": true
+      "integrity": "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA=="
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -1417,8 +1456,7 @@
     "node_modules/list-to-array": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/list-to-array/-/list-to-array-1.1.0.tgz",
-      "integrity": "sha512-+dAZZ2mM+/m+vY9ezfoueVvrgnHIGi5FvgSymbIgJOFwiznWyA59mav95L+Mc6xPtL3s9gm5eNTlNtxJLbNM1g==",
-      "dev": true
+      "integrity": "sha512-+dAZZ2mM+/m+vY9ezfoueVvrgnHIGi5FvgSymbIgJOFwiznWyA59mav95L+Mc6xPtL3s9gm5eNTlNtxJLbNM1g=="
     },
     "node_modules/lodash.deburr": {
       "version": "4.1.0",
@@ -1614,8 +1652,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multimatch": {
       "version": "5.0.0",
@@ -1727,8 +1764,7 @@
     "node_modules/parse-srcset": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
-      "dev": true
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -1803,7 +1839,6 @@
       "version": "0.16.6",
       "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
       "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
-      "dev": true,
       "dependencies": {
         "posthtml-parser": "^0.11.0",
         "posthtml-render": "^3.0.0"
@@ -1816,7 +1851,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
       "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
-      "dev": true,
       "dependencies": {
         "htmlparser2": "^7.1.1"
       },
@@ -1828,7 +1862,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
       "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
-      "dev": true,
       "dependencies": {
         "is-json": "^2.0.1"
       },
@@ -1840,7 +1873,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/posthtml-urls/-/posthtml-urls-1.0.0.tgz",
       "integrity": "sha512-CMJ0L009sGQVUuYM/g6WJdscsq6ooAwhUuF6CDlYPMLxKp2rmCYVebEU+wZGxnQstGJhZPMvXsRhtqekILd5/w==",
-      "dev": true,
       "dependencies": {
         "http-equiv-refresh": "^1.0.0",
         "list-to-array": "^1.1.0",
@@ -1864,7 +1896,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/promise-each/-/promise-each-2.2.0.tgz",
       "integrity": "sha512-67roqt1k3QDA41DZ8xi0V+rF3GoaMiX7QilbXu0vXimut+9RcKBNZ/t60xCRgcsihmNUsEjh48xLfNqOrKblUg==",
-      "dev": true,
       "dependencies": {
         "any-promise": "^0.1.0"
       }
@@ -2145,16 +2176,17 @@
       "dev": true
     },
     "node_modules/set-function-length": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
-      "integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
       "dependencies": {
-        "define-data-property": "^1.1.1",
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.2",
+        "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.1"
+        "has-property-descriptors": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   "license": "ISC",
   "devDependencies": {
     "@11ty/eleventy": "^2.0.1"
+  },
+  "dependencies": {
+    "@11ty/eleventy-plugin-rss": "^1.0.5"
   }
 }

--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -1,0 +1,9 @@
+{
+    "title": "Dangerzone",
+    "description": "The Dangerzone application takes potentially dangerous documents and converts them to safe PDF files",
+    "url": "https://dangerzone.rocks/",
+    "author": {
+      "name": "Dangerzone development team",
+      "email": "info@freedom.press"
+    }
+}

--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -20,32 +20,37 @@
   <meta property="og:url" content="https://dangerzone.rocks">
   <meta property="og:description"
     content="Take potentially dangerous PDFs, office documents, or images and convert them to a safe PDF.">
+  <link rel="alternate" type="application/rss+xml" title="Dangerzone news feed" href="/feed.xml" />
 </head>
 
 <body>
-  <header {% if page.url == '/' %}class="index-header"{% endif %}>
-    <nav class="clearfix">
-      <ul>
-        {# TODO:  We should have more sophisticated nav handling than this #}
-        {% if page.url == '/' %}
-          <li>Main Page</li>
-        {% else %}
-          <li><a href="/">Main Page</a></li>
-        {% endif %}
+<header{% if page.url == '/' %} class="index-header"{% endif %}>
+  <nav class="clearfix">
+    <ul>
+      {% set navItems = [
+        {url: '/', title: 'Main Page'},
+        {url: '/about/', title: 'About'},
+        {url: '/news/', title: 'News'},
+        {url: 'https://github.com/freedomofpress/dangerzone/issues', title: 'Report an Issue', external: true},
+        {url: 'https://github.com/freedomofpress/dangerzone', title: 'Code', external: true},
+        {url: 'https://fosstodon.org/@dangerzone', title: 'Mastodon', external: true, relMe: true}
+      ] %}
 
-        {% if page.url == '/about/' %}
-          <li>About</li>
-        {% else %}
-          <li><a href="/about/">About</a></li>
-        {% endif %}
-        
-        <li><a href="https://github.com/freedomofpress/dangerzone/issues?state=open" target="_blank">Report an Issue</a>
+      {% for item in navItems %}
+        <li>
+          {% if page.url == item.url %}
+            {{ item.title }}
+          {% else %}
+            <a href="{{ item.url }}"
+               {% if item.external %}target="_blank"{% endif %}
+               {% if item.relMe %}rel="me"{% endif %}
+            >{{ item.title }}</a>
+          {% endif %}
         </li>
-        <li><a href="https://github.com/freedomofpress/dangerzone" target="_blank">Code</a></li>
-        <li><a href="https://fosstodon.org/@dangerzone" target="_blank" rel="me">Follow on Mastodon</a></li>
-      </ul>
-    </nav>
-  </header>
+      {% endfor %}
+    </ul>
+  </nav>
+</header>
   <main>
   {{ content | safe | indent(4)}}
   </main>

--- a/src/_layouts/post.njk
+++ b/src/_layouts/post.njk
@@ -1,0 +1,11 @@
+---
+layout: base
+---
+
+<article>
+  <div class="wrapper article">
+    <h1>{{ title }}</h1>
+    <div class="post-time"><time datetime="{{ date | dateIso }}">{{ date | dateReadable }}</time></div>
+    {{ content | safe }}
+  </div>
+</article>

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -109,20 +109,17 @@ a {
 
 /*HEADER*/
 
-header {
-    padding: 1.5rem 1rem;
-    position: absolute;
-    right: 0;
-}
 
 header nav {
     float: right;
     font-size: .75rem;
+    padding:1.5rem;
 }
+
 
 header ul li {
     display: inline;
-    margin: 0 0 0 .5rem;
+    margin: 0 0.5rem 0 0;
 }
 
 .index-header, .index-header a {

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -26,6 +26,15 @@ html {
     /*narrowest iPhone width*/
 }
 
+body {
+    background-color: #592a00;
+}
+
+main {
+
+    background-color: white;
+}
+
 h1 {
     font-size: 4rem;
     line-height: 5.25rem;
@@ -337,7 +346,6 @@ footer {
     font-size: .75rem;
     padding: 1rem;
     border-top: 1px solid rgba(0, 0, 0, 0.1);
-    background-color: #592a00;
     color: #ffffff;
     display: flex;
 }
@@ -438,4 +446,22 @@ ol {
 
 .post-title {
     text-align: left;
+}
+
+.rss-link {
+    display: inline-flex;
+    align-items: center;
+    margin-left: 10px;
+    vertical-align: middle;
+}
+
+.rss-link svg {
+    width: 20px;
+    height: 20px;
+    color: #f26522; /* Standard RSS orange color */
+    transition: color 0.3s ease;
+}
+
+.rss-link:hover svg {
+    color: #e34e0d; /* Slightly darker orange on hover */
 }

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -423,3 +423,19 @@ footer .onion img {
     color: grey;
     font-size: small;
 }
+
+/* Restore numbering for ordered lists */
+ol {
+    list-style-type: decimal;
+    margin-left: 1.5em;
+    padding-left: 1.5em;
+}
+
+.post-time {
+    font-weight: bold;
+    margin-bottom: 1.5em;
+}
+
+.post-title {
+    text-align: left;
+}

--- a/src/feed.njk
+++ b/src/feed.njk
@@ -1,0 +1,27 @@
+---
+permalink: /feed.xml
+eleventyExcludeFromCollections: true
+---
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>{{ site.title }}</title>
+  <subtitle>{{ site.description }}</subtitle>
+  <link href="{{ site.url }}feed.xml" rel="self"/>
+  <link href="{{ site.url }}"/>
+  <updated>{{ collections.blog | getNewestCollectionItemDate | dateToRfc3339 }}</updated>
+  <id>{{ site.url }}</id>
+  <author>
+    <name>{{ site.author.name }}</name>
+    <email>{{ site.author.email }}</email>
+  </author>
+  {%- for post in collections.posts | reverse %}
+  {% set absolutePostUrl %}{{ post.url | url | absoluteUrl(site.url) }}{% endset %}
+  <entry>
+    <title>{{ post.data.title }}</title>
+    <link href="{{ absolutePostUrl }}"/>
+    <updated>{{ post.date | dateToRfc3339 }}</updated>
+    <id>{{ absolutePostUrl }}</id>
+    <content type="html">{{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
+  </entry>
+  {%- endfor %}
+</feed>

--- a/src/news.njk
+++ b/src/news.njk
@@ -4,16 +4,26 @@ title: News
 permalink: /news/
 ---
 <div class="wrapper article">
-  <h1>News</h1>
+  <h1>
+    News
+    <a href="/feed.xml" class="rss-link" title="Subscribe to RSS feed" aria-label="Subscribe to RSS feed">
+      <!-- RSS icon adapted from Feather, MIT license: https://feathericons.com/?query=rss -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M4 11a9 9 0 0 1 9 9"></path>
+        <path d="M4 4a16 16 0 0 1 16 16"></path>
+        <circle cx="5" cy="19" r="1"></circle>
+      </svg>
+    </a>
+  </h1>
   {% for post in collections.posts | reverse %}
     <article>
       <h2 class="post-title"><a href="{{ post.url }}">{{ post.data.title }}</a></h2>
       <div class="post-time"><time datetime="{{ post.date | dateIso }}">{{ post.date | dateReadable }}</time></div>
       
-      {% if post.templateContent | striptags | length < 3000 %}
+      {% if post.templateContent | striptags | length < 1500 %}
         {{ post.templateContent | safe }}
       {% else %}
-        {% set excerpt = post.templateContent | striptags | truncate(500) %}
+        {% set excerpt = post.templateContent | striptags | truncate(1500) %}
         <p>{{ excerpt }}...</p>
         <p><a href="{{ post.url }}">Read more</a></p>
       {% endif %}

--- a/src/news.njk
+++ b/src/news.njk
@@ -1,0 +1,23 @@
+---
+layout: base
+title: News
+permalink: /news/
+---
+<div class="wrapper article">
+  <h1>News</h1>
+  {% for post in collections.posts | reverse %}
+    <article>
+      <h2 class="post-title"><a href="{{ post.url }}">{{ post.data.title }}</a></h2>
+      <div class="post-time"><time datetime="{{ post.date | dateIso }}">{{ post.date | dateReadable }}</time></div>
+      
+      {% if post.templateContent | striptags | length < 3000 %}
+        {{ post.templateContent | safe }}
+      {% else %}
+        {% set excerpt = post.templateContent | striptags | truncate(500) %}
+        <p>{{ excerpt }}...</p>
+        <p><a href="{{ post.url }}">Read more</a></p>
+      {% endif %}
+    </article>
+    {% if not loop.last %}<hr>{% endif %}
+  {% endfor %}
+</div>

--- a/src/news/2024-08-14-welcome.md
+++ b/src/news/2024-08-14-welcome.md
@@ -7,7 +7,7 @@ date: 2024-08-14
 Welcome to the official Dangerzone blog. We will mainly cover:
 - release announcements
 - security updates (e.g., about code audits or vulnerabilities)
-- interest articles related to document sanitization and Dangerzone's inner workings.
+- articles related to document sanitization and Dangerzone's inner workings.
 
 You can follow the blog in your feed reader of choice. If you have thoughts on topics to cover (or would like to draft a post yourself), please don't hesitate to get in touch via our [discussion forums](https://github.com/freedomofpress/dangerzone/discussions).
 

--- a/src/news/2024-08-14-welcome.md
+++ b/src/news/2024-08-14-welcome.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title: Welcome to the Dangerzone
+date: 2024-08-14
+---
+
+Welcome to the official Dangerzone blog. We will mainly cover:
+- release announcements
+- security updates (e.g., about code audits or vulnerabilities)
+- interest articles related to document sanitization and Dangerzone's inner workings.
+
+You can follow the blog in your feed reader of choice. If you have thoughts on topics to cover (or would like to draft a post yourself), please don't hesitate to get in touch via our [discussion forums](https://github.com/freedomofpress/dangerzone/discussions).
+
+Thank you for being part of the Dangerzone community!


### PR DESCRIPTION
Does not yet cover archival of old posts. To add a post, simply create it in `src/news` in the `<ISODATE>-title.md` format, and rebuild.

This introduces our first use of Eleventy's [global data files](https://www.11ty.dev/docs/data-global/), to populate some site metadata for the RSS feed.

I've tested the feed against W3C's feed validator, as well as a text-based RSS reader via `ngrok`:
![Screenshot from 2024-08-13 17-06-53](https://github.com/user-attachments/assets/9b2a8c1e-9828-42ea-b580-aaf3e1134c80)