### PR TITLE
Add announcement for Windows/macOS users

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -554,3 +554,7 @@ figure figcaption {
     font-style: italic;
     font-size: 0.875em;
 }
+
+strong {
+    font-weight: bold;
+}

--- a/src/index.html
+++ b/src/index.html
@@ -41,7 +41,7 @@ layout: base.njk
   <h2>Download Dangerzone 0.7.0</h2>
   🔍 <a href="https://github.com/freedomofpress/dangerzone/blob/v0.7.0/INSTALL.md#verifying-pgp-signatures">How to verify</a>
   </br>
-  <blockquote>📢 Windows and macOS users should read <a href="https://github.com/freedomofpress/dangerzone/issues/933">this</a> after installing Dangerzone and Docker Desktop.</blockquote>
+  <blockquote>📢 <strong>September 2024:</strong> Please follow our <a href="https://github.com/freedomofpress/dangerzone/issues/933">workaround instructions</a> if you are installing Dangerzone and Docker Desktop on <strong>Windows</strong> or <strong>macOS</strong>. </blockquote>
   </br>
   <div class="os-download-container">
     <div class="osPrimary">

--- a/src/index.html
+++ b/src/index.html
@@ -40,6 +40,9 @@ layout: base.njk
 <section id="downloads" class="wrapper clearfix">
   <h2>Download Dangerzone 0.7.0</h2>
   🔍 <a href="https://github.com/freedomofpress/dangerzone/blob/v0.7.0/INSTALL.md#verifying-pgp-signatures">How to verify</a>
+  </br>
+  <blockquote>📢 Windows and macOS users should read <a href="https://github.com/freedomofpress/dangerzone/issues/933">this</a> after installing Dangerzone and Docker Desktop.</blockquote>
+  </br>
   <div class="os-download-container">
     <div class="osPrimary">
       <img src="assets/img/apple-logo.png" alt="Apple Logo">


### PR DESCRIPTION
New Windows / macOS users will be affected by a recent Docker Desktop change, and Dangerzone will not work until they change a specific setting.  Add this announcement in the downloads page, to let people know sooner.

Refs freedomofpress/dangerzone#933