### PR TITLE
Announce Dangerzone 0.8.0

### DIFF
--- a/src/about.md
+++ b/src/about.md
@@ -6,7 +6,7 @@ layout: article.njk
 About Dangerzone
 ================
 
-**By Micah Lee**
+**Original by Micah Lee, with additions from Dangerzone contributors**
 
 Have you ever heard the computer security advice, “Don’t open attachments”? This is solid advice, but unfortunately for journalists, activists, and many other people, it’s impossible to follow. Imagine if you were a journalist and got an email from someone claiming to work for the Trump Organization with “Donald Trump tax returns.pdf” attached. Are you really going to reply saying, “Sorry, I don’t open attachments” and leave it at that?
 

--- a/src/about.md
+++ b/src/about.md
@@ -53,7 +53,7 @@ It uses [gVisor](https://gvisor.dev/) sandboxes running in Linux containers to o
 How does Dangerzone work?
 -------------------------
 
-Dangerzone uses Linux containers (two of them), which are isolated application environments that share the Linux kernel with their host. The easiest way to get containers running on Mac and Windows is by using [Docker Desktop](https://www.docker.com/products/docker-desktop). So when you first install Dangerzone, if you don’t already have Docker Desktop installed, it helps you download and install it.
+Dangerzone uses Linux containers, which are isolated application environments that share the Linux kernel with their host. The easiest way to get containers running on Mac and Windows is by using [Docker Desktop](https://www.docker.com/products/docker-desktop). So when you first install Dangerzone, if you don’t already have Docker Desktop installed, it helps you download and install it.
 
 When Dangerzone starts the container that will sanitize the suspicious document, it will first start a gVisor sandbox _inside_ that container, then run the potentially-dangerous document processing workload inside the sandbox. This ensures that the process dealing with the document is isolated from the Linux kernel. The sandbox and its parent container are also both configured to _disable networking_ and to not mount anything from the host filesystem. So if a malicious document manages to execute arbitrary code, this code doesn’t have access to the host kernel, doesn't have access to your data, and can't use the internet, so there’s not much it could do.
 
@@ -64,14 +64,13 @@ Here’s how it works. First, the sandbox:
 * Uses _PyMuPDF_ to split PDF into individual pages, and to convert those into RGB pixel data
 * _Writes the number of pages and the RGB pixel data to its standard output_
 
-Then that sandbox quits. The host then writes the RGB pixel data to a volume. A second container starts and:
+Then that sandbox quits. The host reads the RGB pixel data from the container's standard output and:
 
-* _Mounts a volume with the RGB pixel data_
 * If OCR is enabled, uses _PyMuPDF_ to convert RGB pixel data into a compressed, **searchable** PDF
 * Otherwise uses _PyMuPDF_ to convert RGB pixel data into a compressed, **flat** PDF
-* _Stores safe PDF in separate volume_
+* _Stores the safe PDF in the specified directory with the `-safe.pdf` suffix, and archives the original one_
 
-Then that container quits, and the user can open the newly created safe PDF.
+The user can then open the newly created safe PDF.
 
 Here are types of documents that Dangerzone can convert into safe PDFs:
 

--- a/src/index.html
+++ b/src/index.html
@@ -101,8 +101,8 @@ layout: base.njk
       if you can trust (for example, an email attachment). Inside of a sandbox,
       Dangerzone converts the document to a PDF (if it isn't already one), and
       then converts the PDF into raw pixel data: a huge list of of RGB color
-      values for each page. Then, in a separate sandbox, Dangerzone takes this
-      pixel data and converts it back into a PDF.</p>
+      values for each page. Then, Dangerzone takes this pixel data and converts
+      it back into a PDF.</p>
     <p><a href="about/">Learn more</a></p>
   </div>
 </section>

--- a/src/index.html
+++ b/src/index.html
@@ -38,17 +38,17 @@ layout: base.njk
   </div>
 </section>
 <section id="downloads" class="wrapper clearfix">
-  <h2>Download Dangerzone 0.7.1</h2>
-  🔍 <a href="https://github.com/freedomofpress/dangerzone/blob/v0.7.1/INSTALL.md#verifying-pgp-signatures">How to verify</a>
+  <h2>Download Dangerzone 0.8.0</h2>
+  🔍 <a href="https://github.com/freedomofpress/dangerzone/blob/v0.8.0/INSTALL.md#verifying-pgp-signatures">How to verify</a>
   </br>
   <div class="os-download-container">
     <div class="osPrimary">
       <img src="assets/img/apple-logo.png" alt="Apple Logo">
       <p class="title">MacOS</p>
         <a class="button"
-            href="https://github.com/freedomofpress/dangerzone/releases/download/v0.7.1/Dangerzone-0.7.1-i686.dmg">Intel chip</a>
+            href="https://github.com/freedomofpress/dangerzone/releases/download/v0.8.0/Dangerzone-0.8.0-i686.dmg">Intel chip</a>
         <a class="button"
-        href="https://github.com/freedomofpress/dangerzone/releases/download/v0.7.1/Dangerzone-0.7.1-arm64.dmg">Apple Silicon chip</a>
+        href="https://github.com/freedomofpress/dangerzone/releases/download/v0.8.0/Dangerzone-0.8.0-arm64.dmg">Apple Silicon chip</a>
         <p class="cpu-arch-info">&#8505;&#65039;
           <a href="https://support.apple.com/en-us/HT211814">Which one do I have?</a>
         </p>
@@ -57,7 +57,7 @@ layout: base.njk
       <img src="assets/img/windows-logo.png" alt="Windows Logo">
       <p class="title">Windows</p>
       <a class="button"
-        href="https://github.com/freedomofpress/dangerzone/releases/download/v0.7.1/Dangerzone-0.7.1.msi">Download for
+        href="https://github.com/freedomofpress/dangerzone/releases/download/v0.8.0/Dangerzone-0.8.0.msi">Download for
         Windows</a>
         <p class="cpu-arch-info">&#65039; <!-- invalid emoji to display same-height whitespace as macOS -->
           <p></p>
@@ -69,13 +69,13 @@ layout: base.njk
       <img src="assets/img/ubuntu-logo.png" alt="Ubuntu Logo">
       <p class="title">Ubuntu / Debian</p>
       <a class="button"
-        href="https://github.com/freedomofpress/dangerzone/blob/v0.7.1/INSTALL.md#ubuntu-debian">Install</a>
+        href="https://github.com/freedomofpress/dangerzone/blob/v0.8.0/INSTALL.md#ubuntu-debian">Install</a>
     </div>
     <div class="osSecondary">
       <img src="assets/img/fedora-logo.png" alt="Fedora Logo">
       <p class="title">Fedora</p>
       <a class="button"
-        href="https://github.com/freedomofpress/dangerzone/blob/v0.7.1/INSTALL.md#fedora">Install</a>
+        href="https://github.com/freedomofpress/dangerzone/blob/v0.8.0/INSTALL.md#fedora">Install</a>
     </div>
     <div class="osSecondary">
       <img src="assets/img/tails-logo.svg" alt="Tails Logo">
@@ -90,7 +90,7 @@ layout: base.njk
     <div class="osSecondary">
       <img src="assets/img/qubes-os-logo.png" alt="Qubes OS Logo">
       <p class="title">Qubes OS (Beta)</p>
-      <a class="button" href="https://github.com/freedomofpress/dangerzone/blob/v0.7.1/INSTALL.md#qubes-os">Install</a>
+      <a class="button" href="https://github.com/freedomofpress/dangerzone/blob/v0.8.0/INSTALL.md#qubes-os">Install</a>
     </div>
   </div>
 </section>

--- a/src/index.html
+++ b/src/index.html
@@ -67,7 +67,7 @@ layout: base.njk
   <div class="os-download-container">
     <div class="osSecondary">
       <img src="assets/img/ubuntu-logo.png" alt="Ubuntu Logo">
-      <p class="title">Ubuntu / Debian / Linux Mint</p>
+      <p class="title">Ubuntu / Debian</p>
       <a class="button"
         href="https://github.com/freedomofpress/dangerzone/blob/v0.7.1/INSTALL.md#ubuntu-debian">Install</a>
     </div>

--- a/src/news/2024-11-06-0.8.0.md
+++ b/src/news/2024-11-06-0.8.0.md
@@ -1,0 +1,50 @@
+---
+layout: post
+title: Dangerzone 0.8.0 is out
+date: 2024-11-06
+---
+
+This release includes various new features, stability improvements and security fixes. If you are on a Mac or PC you should additionally ensure that the Docker Desktop application is up to date. In addition to the changes specific to this release, we want to note that you can now **use Dangerzone on the Tails live system**. You can read the [announcement](https://tails.net/news/dangerzone/index.en.html) on their blog, or [read the documentation](https://tails.net/doc/persistent_storage/additional_software/dangerzone/index.en.html) about it.
+
+The highlights are:
+
+- **The second phase of the conversion (pixels to PDF) now happens on the host.**
+
+  Instead of first grabbing all of the pixel data from the first container, storing them on disk, and then reconstructing the PDF on a second container, Dangerzone now immediately reconstructs the PDF **on the host**, while the doc to pixels conversion is still running on the first container. This architectural change removes a class of problems we had in the past:
+
+    - Issues with temporary directories and their permissions.
+    - Out of space issues caused by documents with lots of pages (mainly impacted Qubes users).
+    - SELinux issues due to relabeling mounted files.
+    - Mounting files to Docker containers, prevented by security policies in Windows/macOS.
+    - Not being able to run with user ID other than 1000.
+
+  If at some point in time you were affected by the above, we suggest giving this version a shot. The sanitization is no less safe, since the boundaries between the sandbox and the host are still respected ([#625](https://github.com/freedomofpress/dangerzone/issues/625)).
+
+- Installation and execution errors are now caught and displayed in the interface, which should make debugging easier ([#193](https://github.com/freedomofpress/dangerzone/issues/193))
+
+- The macOS entitlements have been revisited, following our security audit. We have now removed unneeded privileges ([#638](https://github.com/freedomofpress/dangerzone/issues/638))
+
+- We now always use our own _seccomp_ policy as a default ([#908](https://github.com/freedomofpress/dangerzone/issues/908))
+
+## Platform support updates
+
+- **This release is the last one that will support Ubuntu Focal (20.04).**
+
+  Ubuntu Focal is nearing its end of life date, due in April 2nd, 2025 ([#965](https://github.com/freedomofpress/dangerzone/issues/965)). We urge you to update to a newer Ubuntu version in order to get security updates.
+- Add support for Fedora 41 ([#947](https://github.com/freedomofpress/dangerzone/issues/947))
+- Add support for Ubuntu 24.10 ([#954](https://github.com/freedomofpress/dangerzone/pull/954))
+- Drop support for Ubuntu Mantic (23.10), since it's end-of-life ([#977](https://github.com/freedomofpress/dangerzone/pull/977))
+
+## Community contributions
+
+For this release, we had some help from community members. We want to thank:
+
+- @bnewc, who improved the interface, effectively preventing our users from using illegal characters in the output filename ([#362](https://github.com/freedomofpress/dangerzone/issues/362))
+- @amnak613, who allowed us to report some stray conversion errors ([#776](https://github.com/freedomofpress/dangerzone/issues/776))
+- @jkarasti, who helped us change the signature mechanism from SHA1 to SHA256 for our Windows installer ([#931](https://github.com/freedomofpress/dangerzone/pull/931))
+
+---
+
+On a final note, the container image embedded in the Debian packages differs from the one attached to the release. You can have a look at issue [#988](https://github.com/freedomofpress/dangerzone/issues/988) for more details.
+
+As usual, for a full list of changes, see our [changelog](https://github.com/freedomofpress/dangerzone/blob/main/CHANGELOG.md#080).


### PR DESCRIPTION
Update the website to mark the Dangerzone 0.8.0 release:
- Add a release announcement in our _News_ section, copied from the GitHub release.
- Update the About section to remove references to the second container, now that the pixels to PDF conversion happens on the host.
- Bump the download links to point to our 0.8.0 artifacts.