### PR TITLE
Add simple drawer navigation for mobile

### DIFF
--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html lang="en">
-
+<html lang="en" class="no-js">
 <head>
+  <script>document.documentElement.classList.remove('no-js');</script>
   <meta charset="utf-8">
   <title>{{ title | default("Dangerzone: Convert potentially dangerous documents into safe PDFs") }}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -25,7 +25,11 @@
 
 <body>
 <header{% if page.url == '/' %} class="index-header"{% endif %}>
-  <nav class="clearfix">
+  <button id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-controls="nav-drawer">
+    <span class="sr-only">Menu</span>
+    <span class="hamburger"></span>
+  </button>
+  <nav id="nav-drawer" class="nav-drawer clearfix">
     <ul>
       {% set navItems = [
         {url: '/', title: 'Main Page'},
@@ -39,10 +43,10 @@
       {% for item in navItems %}
         <li>
           {% if page.url == item.url %}
-            {{ item.title }}
+            <span class="current-page">{{ item.title }}</span>
           {% else %}
             <a href="{{ item.url }}"
-               {% if item.external %}target="_blank"{% endif %}
+               {% if item.external %}target="_blank" rel="noopener"{% endif %}
                {% if item.relMe %}rel="me"{% endif %}
             >{{ item.title }}</a>
           {% endif %}
@@ -66,6 +70,7 @@
       </div>
     </div>
   </footer>
+  <script src="/assets/js/drawer.js"></script>
 </body>
 
 </html>

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -560,3 +560,180 @@ figure figcaption {
 strong {
   font-weight: bold;
 }
+
+/* Navigation Drawer Styles */
+/* Accessibility helpers */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Mobile Toggle Button */
+.nav-toggle {
+  display: none;  /* Hidden by default on desktop */
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 10px;
+  z-index: 1001;
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+}
+
+/* Creates the three-line "hamburger" icon for the mobile navigation */
+.hamburger,
+.hamburger::before,
+.hamburger::after {
+  display: block;
+  width: 24px;
+  height: 2px;
+  background-color: #592a00;
+  position: relative;
+  transition: all 0.3s ease-in-out;
+}
+
+/* Adjust the hamburger color on the homepage to account for its dark background */
+.index-header .hamburger,
+.index-header .hamburger::before,
+.index-header .hamburger::after {
+  background-color: #ffffff;
+}
+
+.hamburger::before,
+.hamburger::after {
+  content: '';
+  position: absolute;
+  left: 0;
+}
+
+.hamburger::before {
+  top: -8px;
+}
+
+.hamburger::after {
+  top: 8px;
+}
+
+
+/* Transform the hamburger into an "x" to close when the menu is expanded */
+.nav-toggle[aria-expanded="true"] .hamburger {
+  background: transparent;
+}
+
+.nav-toggle[aria-expanded="true"] .hamburger::before {
+  transform: rotate(45deg);
+  top: 0;
+}
+
+.nav-toggle[aria-expanded="true"] .hamburger::after {
+  transform: rotate(-45deg);
+  top: 0;
+}
+
+/* Current page indicator */
+.current-page {
+  font-weight: bold;
+}
+
+/* Collapse menu into icon on mobile screen resolutions */
+@media screen and (max-width: 768px) {
+  .nav-toggle {
+    display: block;
+  }
+
+  .nav-drawer {
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 80%;
+    max-width: 300px;
+    height: 100vh;
+    background-color: white;
+    padding: 4rem 1.5rem 1.5rem;
+    box-shadow: -2px 0 10px rgba(0,0,0,0.1);
+    z-index: 1000;
+    transform: translateX(100%);
+    overflow-y: auto;
+    transition: transform 0.3s ease-in-out;
+  }
+
+  .index-header .nav-drawer {
+    background-color: #592a00;
+  }
+
+  .nav-drawer.open {
+    transform: translateX(0);
+  }
+
+  .nav-drawer li {
+    display: block;
+    margin: 0;
+    padding: 0.75rem 0;
+    border-bottom: 1px solid rgba(0,0,0,0.1);
+  }
+
+  .index-header .nav-drawer li {
+    border-bottom-color: rgba(255,255,255,0.1);
+  }
+
+  /* Overlay when menu is open, to set the drawer apart from the background */
+  body::after {
+    content: '';
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0,0,0,0.5);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s, visibility 0.3s;
+    z-index: 999;
+    pointer-events: none;
+  }
+
+  body.menu-open::after {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  body.menu-open {
+    overflow: hidden;
+  }
+}
+
+/* Fallback if JavaScript is disabled */
+.no-js .nav-toggle {
+  display: none !important;
+}
+
+.no-js .nav-drawer {
+  position: static;
+  width: auto;
+  height: auto;
+  transform: none;
+  padding: 1.5rem;
+  box-shadow: none;
+  background-color: transparent;
+  overflow: visible;
+}
+
+.no-js .nav-drawer li {
+  display: inline;
+  margin: 0 0.5rem 0 0;
+  padding: 0;
+  border-bottom: none;
+}
+
+.no-js .index-header .nav-drawer {
+  background-color: transparent;
+}

--- a/src/assets/js/drawer.js
+++ b/src/assets/js/drawer.js
@@ -1,0 +1,99 @@
+// Handle the navigation drawer functionality
+(function() {
+  document.addEventListener('DOMContentLoaded', function() {
+    const navToggle = document.getElementById('nav-toggle');
+    const navDrawer = document.getElementById('nav-drawer');
+    const focusableElements = navDrawer.querySelectorAll('a, button, input, select, textarea, [tabindex]:not([tabindex="-1"])');
+
+    // Helper function to check if we're in mobile view (when the toggle button is visible)
+    function isMobileView() {
+      // Use getComputedStyle to check if the button is displayed
+      return window.getComputedStyle(navToggle).display !== 'none';
+    }
+
+    // Helper function to manage tabindexes based on current view and drawer state
+    function updateTabIndexes() {
+      const mobile = isMobileView();
+      const drawerOpen = navDrawer.classList.contains('open');
+
+      focusableElements.forEach(el => {
+        if (mobile && !drawerOpen) {
+          // In mobile view with closed drawer - make not tabbable
+          el.setAttribute('tabindex', '-1');
+        } else {
+          // In desktop view OR open drawer - make tabbable
+          if (el.getAttribute('tabindex') === '-1') {
+            el.removeAttribute('tabindex');
+          }
+        }
+      });
+    }
+
+    // Initial setup
+    updateTabIndexes();
+
+    // Update when window resizes
+    window.addEventListener('resize', updateTabIndexes);
+
+    if (navToggle && navDrawer) {
+      // Toggle menu when button is clicked
+      navToggle.addEventListener('click', function() {
+        const expanded = this.getAttribute('aria-expanded') === 'true';
+        const newExpandedState = !expanded;
+
+        this.setAttribute('aria-expanded', newExpandedState);
+        navDrawer.classList.toggle('open');
+        document.body.classList.toggle('menu-open');
+
+        // Update tabindex based on menu state
+        updateTabIndexes();
+
+        // If opening the menu, focus the first focusable element
+        if (newExpandedState && focusableElements.length > 0) {
+          setTimeout(() => focusableElements[0].focus(), 100);
+        }
+      });
+
+      // Close menu when clicking outside
+      document.addEventListener('click', function(event) {
+        if (navDrawer.classList.contains('open') &&
+            !navDrawer.contains(event.target) &&
+            !navToggle.contains(event.target)) {
+          navToggle.setAttribute('aria-expanded', 'false');
+          navDrawer.classList.remove('open');
+          document.body.classList.remove('menu-open');
+          updateTabIndexes();
+        }
+      });
+
+      // Close menu with Escape key
+      document.addEventListener('keydown', function(event) {
+        if (event.key === 'Escape' && navDrawer.classList.contains('open')) {
+          navToggle.setAttribute('aria-expanded', 'false');
+          navDrawer.classList.remove('open');
+          document.body.classList.remove('menu-open');
+          updateTabIndexes();
+          navToggle.focus();
+        }
+      });
+
+      // Trap focus within the menu when open for accessibility
+      if (focusableElements.length > 0) {
+        const firstFocusable = focusableElements[0];
+        const lastFocusable = focusableElements[focusableElements.length - 1];
+
+        navDrawer.addEventListener('keydown', function(event) {
+          if (event.key === 'Tab' && navDrawer.classList.contains('open') && isMobileView()) {
+            if (event.shiftKey && document.activeElement === firstFocusable) {
+              event.preventDefault();
+              lastFocusable.focus();
+            } else if (!event.shiftKey && document.activeElement === lastFocusable) {
+              event.preventDefault();
+              firstFocusable.focus();
+            }
+          }
+        });
+      }
+    }
+  });
+})();


### PR DESCRIPTION
Resolves #67 

Functionality:
- Collapses the menu on mobile screen resolutions into a "hamburger" icon, which resolves into an "X" when the menu is expanded
- When menu is open, page content fades into the background
- Should support navigation via "tab" when menu is open
- Should be accessible in a screen-reader and use appropriate ARIA attributes
- Should fall back to plain text menu when JavaScript is not executed

Code was generated with Claude 3.7 Reasoning model, using a `code2prompt` input of the existing site (excluding images), and the instruction prompt:

> As you can see, the navigation menu is becoming unwieldy. I would like you to modify it using an accessible but visually appealing drawer approach, which ideally should degrade gracefully if JavaScript is disabled.

I tested & reviewed all generated code, hand-modified some comments, and tweaked to reduce the likelihood of a flash-of-unstyled-content by moving the `no-js` JavaScript execution up further in the head.