### PR TITLE
Add mobile navigation, CSS-based with progressive enhancement

### DIFF
--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -21,36 +21,49 @@
   <meta property="og:description"
     content="Take potentially dangerous PDFs, office documents, or images and convert them to a safe PDF.">
   <link rel="alternate" type="application/rss+xml" title="Dangerzone news feed" href="/feed.xml" />
+  <script src="/assets/js/nav.js">
 </head>
 
 <body>
 <header{% if page.url == '/' %} class="index-header"{% endif %}>
-  <nav class="clearfix">
-    <ul>
-      {% set navItems = [
-        {url: '/', title: 'Main Page'},
-        {url: '/about/', title: 'About'},
-        {url: '/journalists/', title: 'For Journalists'},
-        {url: '/news/', title: 'News'},
-        {url: 'https://github.com/freedomofpress/dangerzone/issues', title: 'Report an Issue', external: true},
-        {url: 'https://github.com/freedomofpress/dangerzone', title: 'Code', external: true},
-        {url: 'https://social.freedom.press/@dangerzone', title: 'Mastodon', external: true, relMe: true}
-      ] %}
+  <input type="checkbox" id="nav-toggle" class="nav-toggle-checkbox" hidden aria-hidden="true">
 
-      {% for item in navItems %}
-        <li>
-          {% if page.url == item.url %}
-            {{ item.title }}
-          {% else %}
-            <a href="{{ item.url }}"
-               {% if item.external %}target="_blank"{% endif %}
-               {% if item.relMe %}rel="me"{% endif %}
-            >{{ item.title }}</a>
-          {% endif %}
-        </li>
-      {% endfor %}
-    </ul>
+  <label for="nav-toggle" class="nav-toggle-label" aria-label="Toggle navigation" tabindex="0">
+    <span class="hamburger-line"></span>
+    <span class="hamburger-line"></span>
+    <span class="hamburger-line"></span>
+  </label>
+
+  <nav class="main-nav clearfix" id="main-nav">
+    <div class="nav-content">
+      <ul>
+        {% set navItems = [
+          {url: '/', title: 'Main Page'},
+          {url: '/about/', title: 'About'},
+          {url: '/journalists/', title: 'For Journalists'},
+          {url: '/news/', title: 'News'},
+          {url: 'https://github.com/freedomofpress/dangerzone/issues', title: 'Report an Issue', external: true},
+          {url: 'https://github.com/freedomofpress/dangerzone', title: 'Code', external: true},
+          {url: 'https://social.freedom.press/@dangerzone', title: 'Mastodon', external: true, relMe: true}
+        ] %}
+
+        {% for item in navItems %}
+          <li {% if page.url == item.url %} class="is-active" {% endif %}>
+            {% if page.url == item.url %}
+              {{ item.title }}
+            {% else %}
+              <a href="{{ item.url }}"
+                 {% if item.external %}target="_blank"{% endif %}
+                 {% if item.relMe %}rel="me"{% endif %}
+              >{{ item.title }}</a>
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
   </nav>
+  <label for="nav-toggle" class="nav-overlay" aria-label="Close navigation"></label>
+
 </header>
   <main>
   {{ content | safe | indent(4)}}
@@ -67,6 +80,7 @@
       </div>
     </div>
   </footer>
+
 </body>
 
 </html>

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -567,3 +567,172 @@ video {
   height: auto;
   display: block;
 }
+
+* {
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  transition: 0.1s;
+}
+
+/* --- Mobile Navigation Drawer Styles --- */
+
+@media (max-width: 959px) {
+
+  header {
+    position: relative;
+    z-index: 1001;
+  }
+
+  .nav-toggle-label {
+    display: block;
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    width: 30px;
+    height: 30px;
+    cursor: pointer;
+    z-index: 1002; /* Above nav and overlay */
+    background: none;
+    border: none;
+    padding: 0;
+  }
+
+  .hamburger-line {
+    display: block;
+    width: 100%;
+    height: 3px;
+    background-color: #999;
+    margin: 5px 0;
+    transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
+    border-radius: 1px;
+  }
+
+  .main-nav {
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 300px;
+    max-width: 80%;
+    height: 100vh;
+    background-color: #333;
+    color: #eee;
+    box-shadow: -2px 0 5px rgba(0, 0, 0, 0.3);
+    transform: translateX(100%);
+    visibility: hidden;
+    transition: transform 0.3s ease-in-out, visibility 0s linear 0.3s;
+    z-index: 1001; /* Above overlay, below toggle */
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* Content area within the nav drawer */
+  .nav-content {
+      flex-grow: 1;
+      overflow-y: auto;
+      padding-top: 4rem;
+      position: relative;
+      z-index: 1;
+  }
+
+  .main-nav ul {
+    list-style: none;
+    padding: 1rem;
+    margin: 0;
+  }
+
+  .main-nav ul li {
+    display: block;
+    margin: 0 0 0.5rem 0;
+    text-align: left;
+  }
+
+  /* Style links and non-link active items */
+  .main-nav ul li a,
+  .main-nav ul li.is-active {
+    color: #eee;
+    text-decoration: none;
+    font-size: 1.1rem;
+    padding: 0.75rem 1rem;
+    display: block;
+    border-radius: 3px;
+    transition: background-color 0.2s ease, color 0.2s ease;
+  }
+
+  /* Active item styling */
+  .main-nav ul li.is-active {
+    font-weight: bold;
+    background-color: #f97b25;
+    color: #ffffff;
+  }
+
+  /* Hover/Focus for links */
+  .main-nav ul li:not(.is-active) a:hover,
+  .main-nav ul li:not(.is-active) a:focus {
+    background-color: #555;
+    color: #eee;
+    outline: none;
+  }
+
+  /* Background Overlay */
+  .nav-overlay {
+    display: block; /* Always in DOM, visibility controlled by opacity/vis */
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.7); /* Darker overlay */
+    z-index: 1000; /* Below nav drawer, above page content */
+    cursor: pointer;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s ease-in-out, visibility 0s linear 0.3s; /* Match nav transition */
+  }
+
+
+  /* --- Styles when the checkbox is checked (menu is open) --- */
+
+  /* Show Nav */
+  .nav-toggle-checkbox:checked ~ .main-nav {
+    transform: translateX(0);
+    visibility: visible;
+    transition: transform 0.3s ease-in-out, visibility 0s linear 0s;
+  }
+
+  /* Show Overlay */
+  .nav-toggle-checkbox:checked ~ .nav-overlay {
+    opacity: 1;
+    visibility: visible;
+    transition: opacity 0.3s ease-in-out, visibility 0s linear 0s;
+  }
+
+  /* Animate hamburger to X */
+  .nav-toggle-checkbox:checked ~ .nav-toggle-label .hamburger-line:nth-child(1) {
+    transform: translateY(8px) rotate(45deg);
+  }
+  .nav-toggle-checkbox:checked ~ .nav-toggle-label .hamburger-line:nth-child(2) {
+    opacity: 0;
+  }
+  .nav-toggle-checkbox:checked ~ .nav-toggle-label .hamburger-line:nth-child(3) {
+    transform: translateY(-8px) rotate(-45deg);
+  }
+
+  /* Ensure original header nav styling doesn't interfere */
+  header nav {
+    float: none;
+    padding: 0;
+    font-size: inherit;
+  }
+  header nav ul li {
+     margin: 0 0 1rem 0;
+  }
+} /* End mobile styles */
+
+/* Desktop nav styles */
+@media (min-width: 960px) {
+   /* Active menu item */
+  header .main-nav ul li.is-active {
+      font-weight: bold;
+  }
+}

--- a/src/assets/js/nav.js
+++ b/src/assets/js/nav.js
@@ -1,0 +1,107 @@
+document.addEventListener('DOMContentLoaded', () => {
+  // --- Elements ---
+  const navToggle = document.getElementById('nav-toggle');
+  const mainNav = document.getElementById('main-nav');
+  const navContent = mainNav?.querySelector('.nav-content');
+  const toggleLabel = document.querySelector('.nav-toggle-label');
+
+  // --- Constants ---
+  const MOBILE_BREAKPOINT = 960; // Match CSS breakpoint
+  const FOCUSABLE_SELECTOR = 'a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled])';
+
+  // --- State ---
+  let isMobile = window.innerWidth < MOBILE_BREAKPOINT;
+  let focusableElements = [];
+  let firstFocusableElement = null;
+  let lastFocusableElement = null;
+
+  // --- Guard Clause ---
+  if (!navToggle || !mainNav || !navContent || !toggleLabel) {
+    console.warn('Mobile navigation elements missing, script not initialized.');
+    return;
+  }
+
+  // --- Functions ---
+  function updateFocusableElements() {
+    focusableElements = Array.from(
+      navContent.querySelectorAll(FOCUSABLE_SELECTOR)
+    );
+    firstFocusableElement = focusableElements[0] || null;
+    lastFocusableElement = focusableElements[focusableElements.length - 1] || null;
+  }
+
+  function handleFocusTrap(e) {
+    // Only trap focus when mobile and the nav is open
+    if (!isMobile || !navToggle.checked) return;
+
+    const isTabPressed = e.key === 'Tab' || e.keyCode === 9;
+    if (!isTabPressed) return;
+
+    // If there are no focusable elements, don't trap
+    if (!firstFocusableElement) {
+        e.preventDefault(); // Prevent tabbing out of an empty menu
+        return;
+    }
+
+    if (e.shiftKey) { // Shift + Tab
+      // If focused on the first element, wrap to the last
+      if (document.activeElement === firstFocusableElement) {
+        lastFocusableElement.focus();
+        e.preventDefault();
+      }
+    } else { // Tab
+      // If focused on the last element, wrap to the first
+      if (document.activeElement === lastFocusableElement) {
+        firstFocusableElement.focus();
+        e.preventDefault();
+      }
+    }
+  }
+
+  function setNavOpenState(isOpen) {
+    if (isOpen && isMobile) {
+      updateFocusableElements();
+      // Delay focus slightly to allow CSS transition
+      setTimeout(() => {
+        firstFocusableElement?.focus();
+      }, 150); // Short delay after opening animation starts
+      mainNav.addEventListener('keydown', handleFocusTrap);
+      document.body.style.overflow = 'hidden'; // Prevent background scroll
+    } else {
+      mainNav.removeEventListener('keydown', handleFocusTrap);
+      document.body.style.overflow = ''; // Restore background scroll
+    }
+  }
+
+  function handleResize() {
+    const stillIsMobile = window.innerWidth < MOBILE_BREAKPOINT;
+    if (isMobile !== stillIsMobile) {
+      isMobile = stillIsMobile;
+      // Re-evaluate open state on resize (especially if crossing breakpoint)
+      setNavOpenState(navToggle.checked);
+    }
+  }
+
+  // --- Event Listeners ---
+  navToggle.addEventListener('change', () => setNavOpenState(navToggle.checked));
+  window.addEventListener('resize', handleResize, { passive: true }); // Use passive listener for resize
+  toggleLabel.addEventListener('keydown', (e) => {
+    // Toggle menu when Enter or Space is pressed
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      navToggle.checked = !navToggle.checked;
+      navToggle.dispatchEvent(new Event('change'));
+    }
+  });
+
+  // Close nav on Escape key
+  document.addEventListener('keydown', (e) => {
+    if (isMobile && navToggle.checked && (e.key === 'Escape')) {
+      navToggle.checked = false; // This will trigger the 'change' event listener above
+    }
+  });
+
+  // --- Initial Setup ---
+  handleResize();
+  setNavOpenState(navToggle.checked);
+});


### PR DESCRIPTION
Resolves #67

Add a mobile navigation menu. 

Pure CSS version features:
- Hamburger-style menu with animation
- Fade background when menu is active

JavaScript progressive enhancements:
- Tab capture when menu is active
- Activate menu with Space/Enter, exit menu with Escape
- Prevent background scrolling when menu is expanded

Desktop screen size behavior should remain unchanged.

Used both Gemini 2.5 and Claude 3.7 a fair bit in iterating on this.