### PR TITLE
Fix headers (h1 to h2)

### DIFF
--- a/src/news/2025-04-09-0.9.0.md
+++ b/src/news/2025-04-09-0.9.0.md
@@ -15,7 +15,7 @@ For this release, the highlights are:
 - The CLI can now run with a `--debug` flag to help retrieve more logs ([#941](https://github.com/freedomofpress/dangerzone/pull/941)).  
 - Experimental support is now available for Podman Desktop on Windows and macOS ([docs](https://github.com/freedomofpress/dangerzone/blob/main/docs/podman-desktop.md)) 
 
-# Platform support updates
+## Platform support updates
 
 - Add support for Fedora 42 ([#1091](https://github.com/freedomofpress/dangerzone/issues/1091))
 - Add support for Ubuntu 25.04 (Plucky Puffin) ([#1090](https://github.com/freedomofpress/dangerzone/issues/1090))
@@ -23,13 +23,13 @@ For this release, the highlights are:
 - Drop support for Fedora 39 ([#999](https://github.com/freedomofpress/dangerzone/issues/999))
 - Add support for Python 3.13 ([#992](https://github.com/freedomofpress/dangerzone/issues/992))
 
-# Fixed
+## Fixed
 
 - Fix our Debian “trixie” installation instructions using Sequoia PGP ([#1052](https://github.com/freedomofpress/dangerzone/issues/1052))  
 - Fix the way multiprocessing works on macOS ([#873](https://github.com/freedomofpress/dangerzone/issues/873))  
 - Update minimum Docker Desktop version to fix an `stdout` truncation issue ([#1101](https://github.com/freedomofpress/dangerzone/issues/1101))
 
-# Community contributions
+## Community contributions
 
 For this release, we had some help from community members. We want to thank:
 


### PR DESCRIPTION
I literally said during the release "these titles seem too big", thinking it was something with the redesign, but... apparently it was just `h1`-level headers that should be `h2`.

This PR fixes it.