### PR TITLE
Use the latest version of our INSTALL.md

### DIFF
--- a/src/_includes/downloads.njk
+++ b/src/_includes/downloads.njk
@@ -29,13 +29,13 @@
       <img src="/assets/img/ubuntu-logo.png" alt="Ubuntu Logo">
       <p class="title">Ubuntu / Debian</p>
       <a class="button"
-        href="https://github.com/freedomofpress/dangerzone/blob/v{{ version }}/INSTALL.md#ubuntu-debian">Install</a>
+        href="https://github.com/freedomofpress/dangerzone/blob/main/INSTALL.md#ubuntu-debian">Install</a>
     </div>
     <div class="osSecondary">
       <img src="/assets/img/fedora-logo.png" alt="Fedora Logo">
       <p class="title">Fedora</p>
       <a class="button"
-        href="https://github.com/freedomofpress/dangerzone/blob/v{{ version }}/INSTALL.md#fedora">Install</a>
+        href="https://github.com/freedomofpress/dangerzone/blob/main/INSTALL.md#fedora">Install</a>
     </div>
     <div class="osSecondary">
       <img class="image-alt" src="/assets/img/tails-logo.svg" alt="Tails Logo">
@@ -50,7 +50,7 @@
     <div class="osSecondary">
       <img src="/assets/img/qubes-os-logo.png" alt="Qubes OS Logo">
       <p class="title">Qubes OS (Beta)</p>
-      <a class="button" href="https://github.com/freedomofpress/dangerzone/blob/v{{ version }}/INSTALL.md#qubes-os">Install</a>
+      <a class="button" href="https://github.com/freedomofpress/dangerzone/blob/main/INSTALL.md#qubes-os">Install</a>
     </div>
   </div>
   </div>


### PR DESCRIPTION
When we point to our Debian/Ubuntu/Qubes/Fedora instructions, make sure that we actually point to the latest version of these instructions, since it doesn't make sense to point to old ones. For one, you can't install an older version from the repos, and also you don't benefit from changes in our instructions.

Closes #80