### PR TITLE
Add workflow for building+publishing OCI images on push to main branch

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,50 @@
+---
+name: Publish
+
+on:
+  push:
+    branches: ["main"]
+
+env:
+  DEFAULT_BRANCH: main
+
+jobs:
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+    - name: Determine tags
+      id: tags
+      env:
+        BRANCH: ${{ github.ref_name }}
+        SHA: ${{ github.sha }}
+      run: |
+        export TAGS="$BRANCH;$BRANCH-${SHA:0:7}"
+
+        if [ "$BRANCH" = "$DEFAULT_BRANCH" ]; then
+            export TAGS="$TAGS;latest"
+        fi
+
+        echo "tags=$TAGS" >>$GITHUB_OUTPUT
+    outputs:
+        tags: ${{ steps.tags.outputs.tags }}
+
+  build:
+    name: Build
+    uses: freedomofpress/actionslib/.github/workflows/oci-build.yaml@main
+    needs:
+    - prepare
+    permissions:
+      contents: read
+      actions: read
+      packages: write
+    with:
+      context: "."
+      containerfile: deploy/Dockerfile
+      tags: ${{ needs.prepare.outputs.tags }}
+      registry: ghcr.io/freedomofpress/dangerzone-rocks
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
On merge to `main`, builds OCI image and pushes it to `ghcr.io/freedomofpress/dangerzone-rocks

Fixes #87 